### PR TITLE
Feature/pending messages integration

### DIFF
--- a/app/components/header/Header.tsx
+++ b/app/components/header/Header.tsx
@@ -83,7 +83,7 @@ export function Header() {
         {connected && user && (
           <>
             <div className="whitespace-nowrap text-base font-medium text-bolt-elements-textPrimary bg-bolt-elements-background rounded-md border border-bolt-elements-borderColor px-4 py-2">
-              {user.messagesLeft} message{user.messagesLeft === 1 ? '' : 's'} left
+              {user.messagesLeft - user.pendingMessages} message{(user.messagesLeft - user.pendingMessages) === 1 ? '' : 's'} left
             </div>
 
             <ClientOnly>

--- a/app/lib/hooks/useAuth.tsx
+++ b/app/lib/hooks/useAuth.tsx
@@ -10,6 +10,7 @@ interface UserInfo {
   id: string;
   wallet: string;
   messagesLeft: number;
+  pendingMessages: number;
   inviteCode: string;
   discountPercent: number;
   referralsRewards: number;

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -351,10 +351,10 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
         })();
         result.mergeIntoDataStream(dataStream);
       },
-      onError: (error: any) => {
-        //If we encountered an error during AI response we should decrement pending messages
+      onError: async (error: any) => {
+        // If we encountered an error during AI response we should decrement pending messages
         try {
-          fetch(`${import.meta.env.PUBLIC_BACKEND_URL}/billing/decrement-pending-messages`, {
+          await fetch(`${import.meta.env.PUBLIC_BACKEND_URL}/billing/decrement-pending-messages`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -73,10 +73,26 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
     throw new Response('Unauthorized', { status: 401 });
   }
 
-  const user = (await userResponse.json()) as { id: string; messagesLeft: number };
-  if (user.messagesLeft <= 0) {
+  const user = (await userResponse.json()) as { id: string; messagesLeft: number, pendingMessages: number };
+  const usableMessages = user.messagesLeft - user.pendingMessages;
+  if (usableMessages <= 0) {
     throw new Response('No messages left', { status: 402 });
   }
+
+  try {
+    await fetch(`${import.meta.env.PUBLIC_BACKEND_URL}/billing/increment-pending-messages`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+      },
+    });
+  }
+  catch (err) {
+    logger.error('Failed to increment pending messages:', err);
+    throw new Response('Could not increment pending messages.', { status: 500 });
+  }
+
 
   try {
     const totalMessageContent = messages.reduce((acc, message) => acc + message.content, '');
@@ -210,7 +226,7 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
               cumulativeUsage.totalTokens += usage.totalTokens || 0;
             }
 
-            // Decrement messages left
+            //Decrementing both messagesLeft and pendingMessages
             try {
               await fetch(`${import.meta.env.PUBLIC_BACKEND_URL}/billing/decrement-messages-left`, {
                 method: 'POST',
@@ -219,8 +235,15 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
                   ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
                 },
               });
+              await fetch(`${import.meta.env.PUBLIC_BACKEND_URL}/billing/decrement-pending-messages`, {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                  ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+                },
+              });
             } catch (err) {
-              logger.error('Failed to decrement messages left:', err);
+              logger.error('Failed to decrement messages:', err);
             }
 
 
@@ -329,6 +352,18 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
         result.mergeIntoDataStream(dataStream);
       },
       onError: (error: any) => {
+        //If we encountered an error during AI response we should decrement pending messages
+        try {
+          fetch(`${import.meta.env.PUBLIC_BACKEND_URL}/billing/decrement-pending-messages`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+            },
+          });
+        } catch (err) {
+          logger.error('Failed to decrement pending messages:', err);
+        }
         logger.error('Before error (onError)');
         return `Custom error: ${error.message}`;
       },

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -424,6 +424,19 @@ async function chatAction({ context, request }: ActionFunctionArgs) {
       });
     }
 
+    //If we encountered an error during AI response we should decrement pending messages
+    try {
+      await fetch(`${import.meta.env.PUBLIC_BACKEND_URL}/billing/decrement-pending-messages`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+        },
+      });
+    } catch (err) {
+      logger.error('Failed to decrement pending messages:', err);
+    }
+
     throw new Response(null, {
       status: 500,
       statusText: 'Internal Server Error',

--- a/app/routes/api.template.select.ts
+++ b/app/routes/api.template.select.ts
@@ -55,9 +55,13 @@ async function templateSelectAction({ context, request }: ActionFunctionArgs) {
     throw new Response('Unauthorized', { status: 401 });
   }
 
-  const user = (await userResponse.json()) as { id: string; messagesLeft: number };
-  if (user.messagesLeft <= 0) {
-    throw new Response('No messages left', { status: 402 });
+  const user = (await userResponse.json()) as { id: string; messagesLeft: number, pendingMessages: number };
+  const usableMessages = user.messagesLeft - user.pendingMessages;
+  if (usableMessages <= 0) {
+    throw new Response('You have no messages left', {
+      status: 403,
+      statusText: 'Forbidden',
+    });
   }
 
   const systemPrompt = starterTemplateSelectionPrompt(STARTER_TEMPLATES);
@@ -132,7 +136,7 @@ async function templateSelectAction({ context, request }: ActionFunctionArgs) {
 
       logger.info(`Generating response Provider: ${provider.name}, Model: ${modelDetails.name}`);
       logger.info(`Messages:` + `System: ${systemPrompt}` + `User message: ${message}`);
-      
+
 //       return new Response(JSON.stringify({
 //         text: `<selection>
 //   <templateName>vite-react-app</templateName>


### PR DESCRIPTION
Updated logic of calculating usable messages so that the user cannot ask AI anything if their pending messages count is more or equal than messages left. Also updated messages count UI component.
Added message refund logic for the case if AI response fails (in the onError of createDataStream in api.chat.ts, and also in the catch).