### PR TITLE
Feature/preview process kill

### DIFF
--- a/app/components/workbench/Workbench.client.tsx
+++ b/app/components/workbench/Workbench.client.tsx
@@ -384,8 +384,11 @@ export const Workbench = memo(
         }
       };
 
-      if (!hasPreview && selectedView === 'preview') {
-        func();
+      // if (!hasPreview && selectedView === 'preview') {
+      //   func();
+      // }
+      if(!hasPreview){
+        customPreviewState.current = 'No preview available.';
       }
     }, [selectedView])
 

--- a/app/lib/aimpactshell/aimpactShell.ts
+++ b/app/lib/aimpactshell/aimpactShell.ts
@@ -88,11 +88,6 @@ export class AimpactShell {
 
   async executeCommand(command: string, abort?: () => void): Promise<ExecutionResult>{
     const sandbox = await this.sandboxPromise;
-    //Before executing the command, we pass it through all preprocessors.
-    for (const preprocessor of this.commandPreprocessors) {
-      command = await preprocessor.process(command);
-    }
-
     if (this.executionState){
       console.log("Execution state is already set, aborting previous command.");
       //Some command is currently running, we need to abort it first.
@@ -115,6 +110,10 @@ export class AimpactShell {
       command: command,
       runAsync: true, //If you run something like 'npm run dev' in sync mode you will wait for it forever.
     };
+    //Before executing the command, we pass it through all preprocessors.
+    for (const preprocessor of this.commandPreprocessors) {
+      commandRequest.command = await preprocessor.process(commandRequest.command);
+    }
 
     console.log("Executing command: ", commandRequest.command, "in session:", sessionId);
     const response =

--- a/app/lib/aimpactshell/commandPreprocessors/commandsLists.ts
+++ b/app/lib/aimpactshell/commandPreprocessors/commandsLists.ts
@@ -1,0 +1,6 @@
+﻿export const PREVIEW_COMMANDS = [
+  'pnpm run dev',
+  'npm run dev',
+  'pnpm run vite',
+  'npm run vite',
+];

--- a/app/lib/aimpactshell/commandPreprocessors/previewCommandPreprocessor.ts
+++ b/app/lib/aimpactshell/commandPreprocessors/previewCommandPreprocessor.ts
@@ -6,13 +6,8 @@ import traverse from '@babel/traverse';
 import generate from '@babel/generator';
 import * as t from '@babel/types';
 import { path } from '~/utils/path';
+import { PREVIEW_COMMANDS } from '~/lib/aimpactshell/commandPreprocessors/commandsLists';
 
-const PREVIEW_COMMANDS = [
-  'pnpm run dev',
-  'npm run dev',
-  'pnpm run vite',
-  'npm run vite',
-];
 
 const REPORTER_SCRIPT_FILE_NAME = 'runtimeErrorReporterScript.js';
 const REPORTER_PLUGIN_FILE_NAME = 'runtimeErrorReporterPlugin.js';

--- a/app/lib/aimpactshell/commandPreprocessors/previewKillPreprocessor.ts
+++ b/app/lib/aimpactshell/commandPreprocessors/previewKillPreprocessor.ts
@@ -25,8 +25,7 @@ export class PreviewKillPreprocessor implements CommandPreprocessor  {
       const sandbox = await this.sandboxPromise;
       const port = this.portCatcher.getPort();
       if(port){
-        try {
-          console.log("Killing preview on port " + port);
+        try {;
           const killSessionName = 'kill-session';
           await sandbox.createSession(killSessionName);
           const killCommand: SessionExecuteRequest = {
@@ -35,7 +34,6 @@ export class PreviewKillPreprocessor implements CommandPreprocessor  {
             runAsync: false
           }
           const killResult = await sandbox.executeSessionCommand(killSessionName, killCommand);
-          console.log("Kill result:", killResult);
           await sandbox.deleteSession(killSessionName);
           this.portCatcher.removePort();
         }

--- a/app/lib/aimpactshell/commandPreprocessors/previewKillPreprocessor.ts
+++ b/app/lib/aimpactshell/commandPreprocessors/previewKillPreprocessor.ts
@@ -30,6 +30,7 @@ export class PreviewKillPreprocessor implements CommandPreprocessor  {
           await sandbox.createSession(killSessionName);
           const killCommand: SessionExecuteRequest = {
             //This command finds the process running on the given port, retrieves its PID, and kills it.
+            //It tries to gracefully terminate the process first, and if that fails, it forcefully kills it.
             command: `for pid in $(netstat -tulpn | grep :${port} | awk '{print $7}' | cut -d'/' -f1); do kill $pid; sleep 2; if kill -0 $pid 2>/dev/null; then kill -9 $pid; fi; done`,
             runAsync: false
           }

--- a/app/lib/aimpactshell/commandPreprocessors/previewKillPreprocessor.ts
+++ b/app/lib/aimpactshell/commandPreprocessors/previewKillPreprocessor.ts
@@ -30,7 +30,7 @@ export class PreviewKillPreprocessor implements CommandPreprocessor  {
           await sandbox.createSession(killSessionName);
           const killCommand: SessionExecuteRequest = {
             //This command finds the process running on the given port, retrieves its PID, and kills it.
-            command: `netstat -tulpn | grep :${port} | awk '{print $7}' | cut -d'/' -f1 | xargs kill -9`,
+            command: `for pid in $(netstat -tulpn | grep :${port} | awk '{print $7}' | cut -d'/' -f1); do kill $pid; sleep 2; if kill -0 $pid 2>/dev/null; then kill -9 $pid; fi; done`,
             runAsync: false
           }
           const killResult = await sandbox.executeSessionCommand(killSessionName, killCommand);

--- a/app/lib/aimpactshell/commandPreprocessors/previewKillPreprocessor.ts
+++ b/app/lib/aimpactshell/commandPreprocessors/previewKillPreprocessor.ts
@@ -1,0 +1,50 @@
+﻿import  { type CommandPreprocessor } from '~/lib/aimpactshell/commandPreprocessors/commandPreprocessor';
+import { AimpactSandbox } from '~/lib/daytona/aimpactSandbox';
+import { PreviewPortCatcher } from '~/utils/previewPortCatcher';
+import { PREVIEW_COMMANDS } from '~/lib/aimpactshell/commandPreprocessors/commandsLists';
+import type { SessionExecuteRequest } from '@daytonaio/api-client';
+
+/**
+ * This class memorizes the last command that went through it.
+ * If the last command was a preview command, then this class will kill the process running on the preview port.
+ */
+export class PreviewKillPreprocessor implements CommandPreprocessor  {
+  private sandboxPromise: Promise<AimpactSandbox>;
+  private lastCommand: string;
+  private portCatcher: PreviewPortCatcher;
+
+  constructor(sandboxPromise: Promise<AimpactSandbox>, portCatcher: PreviewPortCatcher) {
+    this.sandboxPromise = sandboxPromise;
+    this.lastCommand = '';
+    this.portCatcher = portCatcher;
+  }
+
+  async process(command: string): Promise<string> {
+    // If the last command started a preview process, then we need to kill it before running the new command.
+    if(PREVIEW_COMMANDS.includes(this.lastCommand) || PREVIEW_COMMANDS.includes(command)) {
+      const sandbox = await this.sandboxPromise;
+      const port = this.portCatcher.getPort();
+      if(port){
+        try {
+          console.log("Killing preview on port " + port);
+          const killSessionName = 'kill-session';
+          await sandbox.createSession(killSessionName);
+          const killCommand: SessionExecuteRequest = {
+            //This command finds the process running on the given port, retrieves its PID, and kills it.
+            command: `netstat -tulpn | grep :${port} | awk '{print $7}' | cut -d'/' -f1 | xargs kill -9`,
+            runAsync: false
+          }
+          const killResult = await sandbox.executeSessionCommand(killSessionName, killCommand);
+          console.log("Kill result:", killResult);
+          await sandbox.deleteSession(killSessionName);
+          this.portCatcher.removePort();
+        }
+        catch (e) {
+          console.error('Failed to kill port ' + port, e);
+        }
+      }
+    }
+    this.lastCommand = command;
+    return Promise.resolve(command);
+  }
+}

--- a/app/lib/aimpactshell/commandPreprocessors/previewKillPreprocessor.ts
+++ b/app/lib/aimpactshell/commandPreprocessors/previewKillPreprocessor.ts
@@ -25,7 +25,7 @@ export class PreviewKillPreprocessor implements CommandPreprocessor  {
       const sandbox = await this.sandboxPromise;
       const port = this.portCatcher.getPort();
       if(port){
-        try {;
+        try {
           const killSessionName = 'kill-session';
           await sandbox.createSession(killSessionName);
           const killCommand: SessionExecuteRequest = {

--- a/app/lib/aimpactshell/logsProcessors/logPortCatcher.ts
+++ b/app/lib/aimpactshell/logsProcessors/logPortCatcher.ts
@@ -1,10 +1,10 @@
 ﻿import  { type LogProcessor } from '~/lib/aimpactshell/logsProcessors/logProcessor';
-import { getPortCatcher, type PortCatcher } from '~/utils/portCatcher';
+import { getPortCatcher, type PreviewPortCatcher } from '~/utils/previewPortCatcher';
 
 export class LogPortCatcher implements LogProcessor {
-  private portCatcher: PortCatcher;
+  private portCatcher: PreviewPortCatcher;
 
-  constructor(portCatcher: PortCatcher) {
+  constructor(portCatcher: PreviewPortCatcher) {
     this.portCatcher = portCatcher;
   }
 

--- a/app/lib/daytona/lazySandbox.ts
+++ b/app/lib/daytona/lazySandbox.ts
@@ -6,8 +6,9 @@ import type { AimpactSandbox } from '~/lib/daytona/aimpactSandbox';
 
 const DAYTONA_WORK_DIR = '/home/daytona';
 
-/** Lazily initializes daytona sandbox upon the first use
- * */
+/**
+ * Lazily initializes daytona sandbox upon the first use
+ */
 export class LazySandbox implements AimpactSandbox {
   private readonly apiKey: string;
   private readonly orgId: string;

--- a/app/lib/stores/aimpactPreview.ts
+++ b/app/lib/stores/aimpactPreview.ts
@@ -1,4 +1,4 @@
-﻿import type { PortCatcher } from '~/utils/portCatcher';
+﻿import type { PreviewPortCatcher } from '~/utils/previewPortCatcher';
 import { atom } from 'nanostores';
 import { AimpactSandbox } from '~/lib/daytona/aimpactSandbox';
 
@@ -10,11 +10,11 @@ export interface PreviewInfo {
 
 export class AimpactPreviewStore {
   private sandbox: Promise<AimpactSandbox>;
-  private portCatcher: PortCatcher;
+  private portCatcher: PreviewPortCatcher;
 
   previews = atom<PreviewInfo[]>([]);
 
-  constructor(sandbox: Promise<AimpactSandbox>, portCatcher: PortCatcher) {
+  constructor(sandbox: Promise<AimpactSandbox>, portCatcher: PreviewPortCatcher) {
     this.sandbox = sandbox;
     this.portCatcher = portCatcher;
     this.previews.set([]);

--- a/app/lib/stores/aimpactPreview.ts
+++ b/app/lib/stores/aimpactPreview.ts
@@ -19,9 +19,16 @@ export class AimpactPreviewStore {
     this.portCatcher = portCatcher;
     this.previews.set([]);
 
-    portCatcher.addCallback((port: number) => {
+    portCatcher.addPortCaughtCallback((port: number) => {
       this.onPortChange(port);
     });
+    portCatcher.addPortRemovedCallback((port: number) => {
+      this.onPortRemoved(port);
+    });
+  }
+
+  private onPortRemoved(port: number){
+    this.previews.set([]);
   }
 
   private async onPortChange(port: number){

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -20,7 +20,7 @@ import { getSandbox } from '~/lib/daytona';
 import { getAimpactFs } from '~/lib/aimpactfs';
 import { BuildService } from '~/lib/services/buildService';
 import { AimpactPreviewStore } from '~/lib/stores/aimpactPreview';
-import { getPortCatcher } from '~/utils/portCatcher';
+import { getPortCatcher } from '~/utils/previewPortCatcher';
 
 const { saveAs } = fileSaver;
 

--- a/app/utils/portCatcher.ts
+++ b/app/utils/portCatcher.ts
@@ -1,24 +1,49 @@
 ﻿export class PortCatcher{
   private port: number | undefined; // Default port for Vite
   //Collection of functions to be called when we receive a new port
-  private portChangeCallbacks: Array<(port: number) => void> = [];
-
+  private portCaughtCallbacks: Array<(port: number) => void> = [];
+  private portRemovedCallbacks: Array<(port: number) => void> = [];
 
   putNewPort(port: number): void {
+    if(this.port !== undefined){
+      // If there was a previous port, notify its removal
+      const oldPort = this.port;
+      this.portRemovedCallbacks.forEach(callback => callback(oldPort));
+    }
     this.port = port;
     // Notify all registered callbacks about the new port
-    this.portChangeCallbacks.forEach(callback => callback(port));
-    console.log(`New port set: ${this.port}`);
+    this.portCaughtCallbacks.forEach(callback => callback(port));
+  }
+
+  removePort(){
+    if(this.port !== undefined){
+      const oldPort = this.port;
+      this.port = undefined;
+      // Notify all registered callbacks about the removed port
+      this.portRemovedCallbacks.forEach(callback => callback(oldPort));
+    }
   }
 
   getPort(): number | undefined {
-    console.log(`Current port: ${this.port}`);
     return this.port;
   }
 
-  addCallback(callback: (port: number) => void): void {
-    this.portChangeCallbacks.push(callback);
-    console.log(`Callback added. Total callbacks: ${this.portChangeCallbacks.length}`);
+  /**
+   * Callbacks registered here will be called every time a port is removed.
+   * Calls also happen when a new port is caught, so the previous one is removed.
+   * If there was no previous port, callbacks will not be called.
+   * @param callback
+   */
+  addPortRemovedCallback(callback: ((port: number) => void)): void {
+    this.portRemovedCallbacks.push(callback);
+  }
+
+  /**
+   * Callbacks registered here will be called every time a new port is caught.
+   * @param callback
+   */
+  addPortCaughtCallback(callback: (port: number) => void): void {
+    this.portCaughtCallbacks.push(callback);
   }
 }
 

--- a/app/utils/previewPortCatcher.ts
+++ b/app/utils/previewPortCatcher.ts
@@ -1,4 +1,8 @@
-﻿export class PortCatcher{
+﻿/**
+ * This class is responsible for storing the port on which the preview process is running.
+ * It notifies registered callbacks when a new port is caught or when a port is removed.
+ */
+export class PreviewPortCatcher {
   private port: number | undefined; // Default port for Vite
   //Collection of functions to be called when we receive a new port
   private portCaughtCallbacks: Array<(port: number) => void> = [];
@@ -48,11 +52,11 @@
 }
 
 // Singleton instance of PortCatcher
-let portCatcherInstance: PortCatcher | null = null;
+let portCatcherInstance: PreviewPortCatcher | null = null;
 
-export function getPortCatcher(): PortCatcher {
+export function getPortCatcher(): PreviewPortCatcher {
   if (!portCatcherInstance) {
-    portCatcherInstance = new PortCatcher();
+    portCatcherInstance = new PreviewPortCatcher();
     console.log('PortCatcher instance created');
   } else {
     console.log('Using existing PortCatcher instance');

--- a/app/utils/previewPortCatcher.ts
+++ b/app/utils/previewPortCatcher.ts
@@ -57,9 +57,7 @@ let portCatcherInstance: PreviewPortCatcher | null = null;
 export function getPortCatcher(): PreviewPortCatcher {
   if (!portCatcherInstance) {
     portCatcherInstance = new PreviewPortCatcher();
-    console.log('PortCatcher instance created');
-  } else {
-    console.log('Using existing PortCatcher instance');
   }
+
   return portCatcherInstance;
 }


### PR DESCRIPTION
## 📄 Pull Request Description

This pull requests adds a new command preprocessor (a class that runs some logic before executing commands in AimpactShell) which tracks preview commands (like npm run dev or pnpm run dev) and kills preview processes that were run before. This way we can save daytona computational resources because we allow only one preview process.

---

## ✅ Type of Change

<!-- Check the relevant option(s) below -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor (non-breaking changes that improve code structure)
- [ ] 📝 Documentation update
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚙️ Other (please describe):

---

## 🧪 Test Plan / Results

Manually tested by openinng multiple terminals and running pnpm run command.

---

## 📋 Checklist

- [x] I've tested the feature/bug thoroughly and attached test results or screenshots.
- [ ] I've added or updated necessary documentation (e.g., README, inline comments).
- [ ] I've updated or added relevant tests where needed.
- [x] Code is formatted and linted properly.
- [x] No console errors or warnings in the browser / logs.
- [ ] All existing and new tests pass locally.
- [ ] I have reviewed the code for security and performance implications.

---

## 🚀 Future steps



---

## 💬 Additional Notes



---

## Related Issues / Tickets


