### PR TITLE
Feature/preview compilation error handling

### DIFF
--- a/app/lib/aimpactshell/aimpactShell.ts
+++ b/app/lib/aimpactshell/aimpactShell.ts
@@ -13,6 +13,7 @@ import { EditorScriptsRemover } from '~/lib/aimpactshell/commandPreprocessors/ed
 import { RuntimeErrorProcessor } from '~/lib/aimpactshell/logsProcessors/runtimeErrorProcessor';
 import { CommandBuffer } from '~/lib/aimpactshell/commandBuffer';
 import { ViteConfigSyntaxChecker } from '~/lib/aimpactshell/commandPreprocessors/viteConfigSyntaxChecker';
+import { ViteTerminalErrorProcessor } from '~/lib/aimpactshell/logsProcessors/viteTerminalErrorProcessor';
 
 export type ExecutionResult = { output: string; exitCode: number } | undefined;
 
@@ -158,7 +159,10 @@ export class AimpactShell {
 //log processor for capturing preview port from Daytona.io server.
 export function newAimpactShellProcess(sandboxPromise: Promise<AimpactSandbox>, fsPromise: Promise<AimpactFs>): AimpactShell {
   const portCatcher = getPortCatcher();
-  const logsProcessors = [new LogPortCatcher(portCatcher)];
+  const logsProcessors = [
+    new LogPortCatcher(portCatcher),
+    new ViteTerminalErrorProcessor()
+  ];
   const commandsPreprocessors: CommandPreprocessor[] = [
     new ViteConfigSyntaxChecker(fsPromise),
     new PreviewKillPreprocessor(sandboxPromise, portCatcher),

--- a/app/lib/aimpactshell/logsProcessors/viteTerminalErrorProcessor.ts
+++ b/app/lib/aimpactshell/logsProcessors/viteTerminalErrorProcessor.ts
@@ -1,0 +1,24 @@
+import type { LogProcessor } from '~/lib/aimpactshell/logsProcessors/logProcessor';
+import { workbenchStore } from '~/lib/stores/workbench';
+
+export class ViteTerminalErrorProcessor implements LogProcessor {
+  process(log: string): void {
+    const logsParts = log.split('\n');
+    for (const part of logsParts) {
+      const foundError = part.toLowerCase().includes('error');
+      const foundVite = part.toLowerCase().includes('[vite]');
+      if (foundError && foundVite) {
+        workbenchStore.actionAlert.set (
+          {
+            type: 'error',
+            title: 'Vite error in console',
+            description: `${part.slice(0, 100)}`,
+            content: `${part}`,
+            source: 'terminal'
+          }
+        );
+      }
+    }
+
+  }
+}

--- a/app/lib/aimpactshell/logsProcessors/viteTerminalErrorProcessor.ts
+++ b/app/lib/aimpactshell/logsProcessors/viteTerminalErrorProcessor.ts
@@ -1,12 +1,14 @@
 import type { LogProcessor } from '~/lib/aimpactshell/logsProcessors/logProcessor';
 import { workbenchStore } from '~/lib/stores/workbench';
 
+const VITE_SEARCH_PATTERN = '[vite]';
+
 export class ViteTerminalErrorProcessor implements LogProcessor {
   process(log: string): void {
     const logsParts = log.split('\n');
     for (const part of logsParts) {
       const foundError = part.toLowerCase().includes('error');
-      const foundVite = part.toLowerCase().includes('[vite]');
+      const foundVite = part.toLowerCase().includes(VITE_SEARCH_PATTERN);
       if (foundError && foundVite) {
         workbenchStore.actionAlert.set (
           {

--- a/app/routes/api.daytona.ts
+++ b/app/routes/api.daytona.ts
@@ -63,11 +63,11 @@ function createSandboxIfNotExists(identification: Identification): LazySandbox{
     const apiKey = getEnvVar(context, 'DAYTONA_API_KEY');
     const apiUrl = getEnvVar(context, 'DAYTONA_API_URL');
     const orgId = getEnvVar(context, 'DAYTONA_ORG_ID');
-    const proxyDomain = getEnvVar(context, 'DAYTONA_PROXY_URL');
-    if (!apiKey || !apiUrl || !orgId || !proxyDomain) {
+    const proxyUrl = getEnvVar(context, 'DAYTONA_PROXY_URL');
+    if (!apiKey || !apiUrl || !orgId || !proxyUrl) {
       throw new Error('Missing Daytona API configuration');
     }
-    const sandbox = new LazySandbox(apiUrl, apiKey, orgId, proxyDomain);
+    const sandbox = new LazySandbox(apiUrl, apiKey, orgId, proxyUrl);
     usersSandboxes.set(compositeId, sandbox);
   }
   return usersSandboxes.get(compositeId)!;


### PR DESCRIPTION
## 📄 Pull Request Description

This pullrequest introduces a new log processor for AimpactShell: ViteTerminalErrorProcessor. It checks each log for presence of words vite and error, and creates an alert if both words are present. In theory user can cause it to have false positives by making own server-side logs with both mentioned words, but handling alerts is optional, so this seems acceptable.

---

## ✅ Type of Change

<!-- Check the relevant option(s) below -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking changes that improve code structure)
- [ ] 📝 Documentation update
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚙️ Other (please describe):

---

## 🧪 Test Plan / Results

Manually tested by running the preview with purposefully erroneous code.

---

## 📋 Checklist

- [x] I've tested the feature/bug thoroughly and attached test results or screenshots.
- [ ] I've added or updated necessary documentation (e.g., README, inline comments).
- [ ] I've updated or added relevant tests where needed.
- [x] Code is formatted and linted properly.
- [x] No console errors or warnings in the browser / logs.
- [ ] All existing and new tests pass locally.
- [ ] I have reviewed the code for security and performance implications.

---

## 🚀 Future steps



---

## 💬 Additional Notes


---

## Related Issues / Tickets

