### PR TITLE
Fix: Lag when generating big text files

### DIFF
--- a/app/components/workbench/DiffView.tsx
+++ b/app/components/workbench/DiffView.tsx
@@ -7,7 +7,6 @@ import { diffLines, type Change } from 'diff';
 import { getHighlighter } from 'shiki';
 import '~/styles/diff-view.css';
 import { diffFiles, extractRelativePath } from '~/utils/diff';
-import { ActionRunner } from '~/lib/runtime/action-runner';
 import type { FileHistory } from '~/types/actions';
 import { getLanguageFromExtension } from '~/utils/getLanguageFromExtension';
 import { themeStore } from '~/lib/stores/theme';
@@ -621,10 +620,10 @@ const InlineDiffComparison = memo(({ beforeCode, afterCode, filename, language }
 interface DiffViewProps {
   fileHistory: Record<string, FileHistory>;
   setFileHistory: React.Dispatch<React.SetStateAction<Record<string, FileHistory>>>;
-  actionRunner: ActionRunner;
+  isTabOpen: boolean;
 }
 
-export const DiffView = memo(({ fileHistory, setFileHistory }: DiffViewProps) => {
+export const DiffView = memo(({ fileHistory, setFileHistory, isTabOpen }: DiffViewProps) => {
   const files = useStore(workbenchStore.files) as FileMap;
   const selectedFile = useStore(workbenchStore.selectedFile);
   const currentDocument = useStore(workbenchStore.currentDocument) as EditorDocument;
@@ -714,6 +713,10 @@ export const DiffView = memo(({ fileHistory, setFileHistory }: DiffViewProps) =>
       }
     }
   }, [selectedFile, currentDocument?.value, files, setFileHistory, unsavedFiles]);
+
+  if(!isTabOpen){
+    return (<div></div>);
+  }
 
   if(currentDocument && currentDocument.isBinary){
     return (

--- a/app/components/workbench/Workbench.client.tsx
+++ b/app/components/workbench/Workbench.client.tsx
@@ -577,7 +577,7 @@ export const Workbench = memo(
                     initial={{ x: '100%' }}
                     animate={{ x: selectedView === 'diff' ? '0%' : selectedView === 'code' ? '100%' : '-100%' }}
                   >
-                    <DiffView fileHistory={fileHistory} setFileHistory={setFileHistory} actionRunner={actionRunner} />
+                    <DiffView fileHistory={fileHistory} setFileHistory={setFileHistory} isTabOpen={selectedView === 'diff'} />
                   </View>
                   <View initial={{ x: '100%' }} animate={{ x: selectedView === 'preview' ? '0%' : '100%' }}>
                     <Preview customText={customPreviewState.current} />

--- a/app/routes/api.template.select.ts
+++ b/app/routes/api.template.select.ts
@@ -117,7 +117,8 @@ async function templateSelectAction({ context, request }: ActionFunctionArgs) {
         statusText: 'Internal Server Error',
       });
     }
-  } else {
+  }
+  else {
     try {
       const models = await getModelList({ apiKeys, providerSettings, serverEnv: context.cloudflare?.env as any });
       const modelDetails = models.find((m: ModelInfo) => m.name === model);


### PR DESCRIPTION
## 📄 Pull Request Description

This pull request fixes freezes that occur when AI makes big text modifications. The lag occured because of DiffView component rerendering the InlineDiffComparison component on each modification. In other words, 300 lines changes = 300 rerenders of InlineDiffComparison, which is, apparently, a laggy component. Now DiffView component reutrns an empty div if diff tab is not selected.

---

## ✅ Type of Change

<!-- Check the relevant option(s) below -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking changes that improve code structure)
- [ ] 📝 Documentation update
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚙️ Other (please describe):

---

## 🧪 Test Plan / Results

Tested manually by openning random projects and asking ai to make 150+ lines changes.

---

## 📋 Checklist

- [ ] I've tested the feature/bug thoroughly and attached test results or screenshots.
- [ ] I've added or updated necessary documentation (e.g., README, inline comments).
- [ ] I've updated or added relevant tests where needed.
- [ ] Code is formatted and linted properly.
- [ ] No console errors or warnings in the browser / logs.
- [ ] All existing and new tests pass locally.
- [ ] I have reviewed the code for security and performance implications.

---

## 🚀 Future steps


---

## 💬 Additional Notes


---

## Related Issues / Tickets

